### PR TITLE
Interpret message type as little endian

### DIFF
--- a/dissectors/sci.lua
+++ b/dissectors/sci.lua
@@ -237,9 +237,9 @@ function p_sci.dissector(buf, pktinfo, root)
             local mtype = buf:range(position + 1, 2):uint()
             sci_sub:add(sci_protocol_type, buf:range(position, 1))
             if (sci_type == 0x30) then
-                sci_sub:add(sci_ls_message_type, buf:range(position + 1, 2))
+                sci_sub:add_le(sci_ls_message_type, buf:range(position + 1, 2))
 
-				local msgType = sci_ls_msg_types[buf:range(position + 1, 2):uint()];
+				local msgType = sci_ls_msg_types[buf:range(position + 1, 2):le_uint()];
 				if msgType == nil then
 					pktinfo.cols.info:append(" (Unknown Message Type)")
 				else
@@ -247,9 +247,9 @@ function p_sci.dissector(buf, pktinfo, root)
 				end
             end
             if (sci_type == 0x40) then
-                sci_sub:add(sci_p_message_type, buf:range(position + 1, 2))
+                sci_sub:add_le(sci_p_message_type, buf:range(position + 1, 2))
 
-				local msgType = sci_p_msg_types[buf:range(position + 1, 2):uint()];
+				local msgType = sci_p_msg_types[buf:range(position + 1, 2):le_uint()];
 				if msgType == nil then
 					pktinfo.cols.info:append(" (Unknown Message Type)")
 				else


### PR DESCRIPTION
As defined by Eu.SAS.2083: The applied byte order for Message Type shall be Little-Endian.