### PR TITLE
Fix "attempt to index local 'sci' (a nil value)"

### DIFF
--- a/dissectors/sci.lua
+++ b/dissectors/sci.lua
@@ -216,7 +216,9 @@ function p_sci.dissector(buf, pktinfo, root)
         if ((buf:range(position+2, 1):le_uint() == 0x40) or (buf:range(position+2, 1):le_uint() == 0x30)) then 
             sci = root:add(p_sci, buf(), "SCI")
             pktinfo.cols.protocol:set("SCI")
-           end
+        else
+            return
+        end
     end
 
     while (pktlen - position) >= 45 do


### PR DESCRIPTION
The while loop in sci.lua raises an error if it is "not an SCI-X Packet" because of an undefined `sci`. As there is no way to know how to interpret the unknown data, don't process it at all and return early.