### PR TITLE
Fix error with Wireshark 4.2.0

### DIFF
--- a/dissectors/rasta.lua
+++ b/dissectors/rasta.lua
@@ -37,7 +37,6 @@ set_plugin_info(my_info)
 
 --
 ------------------------
-package.prepend_path("rasta_modules")
 local MD4 = require("md4");
 local Stream = require("stream");
 local CRC = require("rasta_crc");


### PR DESCRIPTION
package.prepend_path() has been removed from Wireshark [1]. As require() searches in subdirectories the function call can simply be removed.

[1] https://gitlab.com/wireshark/wireshark/-/merge_requests/11787