### PR TITLE
Fix lua5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix MD4 implementation with Lua 5.3 bitwise operators.
+
 ## [1.3.0] - 2025-04-04
 
 ### Added

--- a/dissectors/rasta_modules/bit.lua
+++ b/dissectors/rasta_modules/bit.lua
@@ -27,16 +27,7 @@ elseif _VERSION == "Lua 5.1" then
 else
     print("C")
     -- Lua 5.3+ uses built-in bitwise operators
-    bit = {
-        band = function(a, b) return a & b end,
-        bor = function(a, b) return a | b end,
-        bxor = function(a, b) return a ~ b end,
-        rshift = function(a, n) return a >> n end,
-        lshift = function(a, n) return (a << n) & 0xffffffff end,
-        bnot = function(a) return ~a end,
-        lrotate = function(a, n) return ((a << n) & 0xffffffff) | (a >> (32 - n)) & ~(-1 << n) end,
-        rrotate = function(a, n) return (a >> n) | ((a << (32 - n)) & 0xffffffff) end
-    }
+    bit = require("bit54")
 end
 
 return bit  -- Return the selected bitwise library (or table for Lua 5.3+)

--- a/dissectors/rasta_modules/bit.lua
+++ b/dissectors/rasta_modules/bit.lua
@@ -11,26 +11,31 @@ set_plugin_info(my_info)
 
 local bit = nil
 
+print(_VERSION)
+
 if _VERSION == "Lua 5.2" then
+    print("A")
     local ok, e = pcall(require, "bit32")  -- Try bit32 (Lua 5.2)
     if ok then bit = e end
 elseif _VERSION == "Lua 5.1" then
+    print("B")
     local ok, e = pcall(require, "bit")  -- Try LuaJIT bit library
     if not ok then
         ok, e = pcall(require, "bit.numberlua")  -- Try numberlua for Lua 5.1
     end
     if ok then bit = e end
 else
+    print("C")
     -- Lua 5.3+ uses built-in bitwise operators
     bit = {
         band = function(a, b) return a & b end,
         bor = function(a, b) return a | b end,
         bxor = function(a, b) return a ~ b end,
         rshift = function(a, n) return a >> n end,
-        lshift = function(a, n) return a << n end,
+        lshift = function(a, n) return (a << n) & 0xffffffff end,
         bnot = function(a) return ~a end,
-		lrotate = function(a, n) return (a << n) | (a >> (32 - n)) end,
-		rrotate = function(a, n) return (a >> n) | (a << (32 - n)) end
+        lrotate = function(a, n) return ((a << n) & 0xffffffff) | (a >> (32 - n)) end,
+        rrotate = function(a, n) return (a >> n) | ((a << (32 - n)) & 0xffffffff) end
     }
 end
 

--- a/dissectors/rasta_modules/bit.lua
+++ b/dissectors/rasta_modules/bit.lua
@@ -34,7 +34,7 @@ else
         rshift = function(a, n) return a >> n end,
         lshift = function(a, n) return (a << n) & 0xffffffff end,
         bnot = function(a) return ~a end,
-        lrotate = function(a, n) return ((a << n) & 0xffffffff) | (a >> (32 - n)) end,
+        lrotate = function(a, n) return ((a << n) & 0xffffffff) | (a >> (32 - n)) & ~(-1 << n) end,
         rrotate = function(a, n) return (a >> n) | ((a << (32 - n)) & 0xffffffff) end
     }
 end

--- a/dissectors/rasta_modules/bit.lua
+++ b/dissectors/rasta_modules/bit.lua
@@ -11,21 +11,16 @@ set_plugin_info(my_info)
 
 local bit = nil
 
-print(_VERSION)
-
 if _VERSION == "Lua 5.2" then
-    print("A")
     local ok, e = pcall(require, "bit32")  -- Try bit32 (Lua 5.2)
     if ok then bit = e end
 elseif _VERSION == "Lua 5.1" then
-    print("B")
     local ok, e = pcall(require, "bit")  -- Try LuaJIT bit library
     if not ok then
         ok, e = pcall(require, "bit.numberlua")  -- Try numberlua for Lua 5.1
     end
     if ok then bit = e end
 else
-    print("C")
     -- Lua 5.3+ uses built-in bitwise operators
     bit = require("bit54")
 end

--- a/dissectors/rasta_modules/bit54.lua
+++ b/dissectors/rasta_modules/bit54.lua
@@ -1,0 +1,12 @@
+local bit = {
+    band = function(a, b) return a & b end,
+    bor = function(a, b) return a | b end,
+    bxor = function(a, b) return a ~ b end,
+    rshift = function(a, n) return a >> n end,
+    lshift = function(a, n) return (a << n) & 0xffffffff end,
+    bnot = function(a) return ~a end,
+    lrotate = function(a, n) return ((a << n) & 0xffffffff) | (a >> (32 - n)) & ~(-1 << n) end,
+    rrotate = function(a, n) return (a >> n) | ((a << (32 - n)) & 0xffffffff) end
+}
+
+return bit

--- a/dissectors/rasta_modules/test.lua
+++ b/dissectors/rasta_modules/test.lua
@@ -14,6 +14,7 @@ local bit = require("bit")
 print(MD4().update(Stream.fromString("")).finish().asHex()) -- Should be 31d6cfe0d16ae931b73c59d7e0c089c0
 print(MD4().update(Stream.fromHex("24004c183fb49600ceca2300564433226655443357010000cb000000")).finish().asHex()) -- Should be 83f0d052406bf492f89f8d1e9b89c98d
 print(MD4().finish().asHex())
+print(MD4().asHex()) -- 0123456789abcdeffedcba9876543210
 
 print("AND:    " .. bit.band(B, C))     -- 2290649224
 print("OR:     " .. bit.bor(B, C))      -- 4294967295
@@ -30,8 +31,25 @@ local H = function(x,y,z) return bit.bxor(x,bit.bxor(y,z)); end
 
 print("F:      " .. F(B,C,D)) -- 2562383102
 print("F:      " .. F(A,B,C)) -- 4294967295
+print("F:      " .. F(D,A,B)) -- 4023233417
+print("F:      " .. F(C,D,A)) -- 2004318071
 print("G:      " .. G(B,C,D)) -- 2562383102
 print("G:      " .. G(A,B,C)) -- 4023233417
 print("H:      " .. H(B,C,D)) -- 1732584193
+
+print(" 1: " .. bit.band(bit.bnot(B), D)) -- 271733878
+print(" 2: " .. bit.band(B, C)) -- 2290649224
+print(" 3: " .. bit.bor(bit.band(B, C), bit.band(bit.bnot(B), D))) -- 2562383102
+
+print(" 4: " .. bit.band(bit.bnot(A), C)) -- 2562383102
+print(" 5: " .. bit.band(A, B)) -- 1732584193
+print(" 6: " .. bit.bor(bit.band(A, B), bit.band(bit.bnot(A), C))) -- 4294967295
+
+print(" 7: " .. bit.lrotate(A + F(B, C, D), 3)) -- 4294967295
+
+print(" 8: " .. bit.band(A, 0xFFFFFFFF)) -- 1732584193
+print(" 9: " .. A) -- 1732584193
+print("10: " .. bit.lrotate(B + F(C, D, A), 19)) -- 402864681
+print("11: " .. B + F(C, D, A)) -- 6027551488
 
 print(A + B + C + D) -- 8589934590

--- a/dissectors/rasta_modules/test.lua
+++ b/dissectors/rasta_modules/test.lua
@@ -1,0 +1,37 @@
+function set_plugin_info(info)
+    return
+end
+
+local A = 0x67452301;
+local B = 0xefcdab89;
+local C = 0x98badcfe;
+local D = 0x10325476;
+
+local MD4 = require("md4")
+local Stream = require("stream")
+local bit = require("bit")
+
+print(MD4().update(Stream.fromString("")).finish().asHex()) -- Should be 31d6cfe0d16ae931b73c59d7e0c089c0
+print(MD4().update(Stream.fromHex("24004c183fb49600ceca2300564433226655443357010000cb000000")).finish().asHex()) -- Should be 83f0d052406bf492f89f8d1e9b89c98d
+print(MD4().finish().asHex())
+
+print("AND:    " .. bit.band(B, C))     -- 2290649224
+print("OR:     " .. bit.bor(B, C))      -- 4294967295
+print("XOR:    " .. bit.bxor(B, C))     -- 2004318071
+print("RSHIFT: " .. bit.rshift(B, 19))  -- 7673
+print("LSHIFT: " .. bit.lshift(B, 19))  -- 1548222464
+print("NOT:    " .. bit.bnot(B))        -- 271733878
+print("LROT:   " .. bit.lrotate(B, 19)) -- 1548713581
+print("RROT:   " .. bit.rrotate(B, 19)) -- 3044097529
+
+local F = function(x,y,z) return bit.bor(bit.band(x,y),bit.band(bit.bnot(x),z)); end
+local G = function(x,y,z) return bit.bor(bit.band(x,y), bit.bor(bit.band(x,z), bit.band(y,z))); end
+local H = function(x,y,z) return bit.bxor(x,bit.bxor(y,z)); end
+
+print("F:      " .. F(B,C,D)) -- 2562383102
+print("F:      " .. F(A,B,C)) -- 4294967295
+print("G:      " .. G(B,C,D)) -- 2562383102
+print("G:      " .. G(A,B,C)) -- 4023233417
+print("H:      " .. H(B,C,D)) -- 1732584193
+
+print(A + B + C + D) -- 8589934590


### PR DESCRIPTION
Should fix MD4 implementation with built-in bitwise operators of Lua 5.3+.

As the code of the bitwise operators was moved to a different file (Lua < 5.3 throws a syntax error otherwise), the fix is hard to spot. So here is the (pseudo) diff:

```diff
     bit = {
         band = function(a, b) return a & b end,
         bor = function(a, b) return a | b end,
         bxor = function(a, b) return a ~ b end,
         rshift = function(a, n) return a >> n end,
-        lshift = function(a, n) return a << n end,
+        lshift = function(a, n) return (a << n) & 0xffffffff end,
         bnot = function(a) return ~a end,
-        lrotate = function(a, n) return (a << n) | (a >> (32 - n)) end,
+        lrotate = function(a, n) return ((a << n) & 0xffffffff) | (a >> (32 - n)) & ~(-1 << n) end,
-        rrotate = function(a, n) return (a >> n) | (a << (32 - n)) end
+        rrotate = function(a, n) return (a >> n) | ((a << (32 - n)) & 0xffffffff) end
     }

```