### PR TITLE
Feature: Added Request/Response tracking of rasta messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- RaSTA dissector now provides automatic request/response packet correlation via sequence number matching. Original requests show "Request In" links to their responses, and responses show "Response In" links back to the original requests. This enables users to quickly navigate between correlated packets in the protocol tree.
+
 ## [1.4.1] - 2025-12-01
 
 ### Fixed

--- a/dissectors/rasta.lua
+++ b/dissectors/rasta.lua
@@ -117,6 +117,8 @@ local safety_dest_id             = ProtoField.uint32("rasta.safety.dest_id", "Re
 local safety_src_id              = ProtoField.uint32("rasta.safety.src_id", "Sender Identification")
 local safety_sequence_number     = ProtoField.uint32("rasta.safety.sn", "Sequence Number")
 local safety_c_sequence_number   = ProtoField.uint32("rasta.safety.cs", "Confirmed Sequence Number")
+local safety_request_in          = ProtoField.framenum("rasta.safety.request_in",  "Request In",  base.NONE, frametype.REQUEST)
+local safety_response_in         = ProtoField.framenum("rasta.safety.response_in", "Response In", base.NONE, frametype.RESPONSE)
 local safety_timestamp           = ProtoField.uint32("rasta.safety.ts", "Time Stamp")
 local safety_c_timestamp         = ProtoField.uint32("rasta.safety.cts", "Confirmed Time Stamp")
 local safety_protocol_version    = ProtoField.string("rasta.safety.protocol_version", "Protocol Version")
@@ -128,6 +130,8 @@ local safety_reason              = ProtoField.uint16("rasta.safety.reason", "Rea
 local safety_safety_code         = ProtoField.new("Safety Code", "rasta.safety.safety_code", ftypes.BYTES)
 local safety_safety_code_valid   = ProtoField.new("Safety Code valid", "rasta.safety.safety_code_valid", ftypes.BOOLEAN)
 
+local rasta_sn_table = {}   -- (src:sn)  -> frame number of that packet
+local rasta_cs_table = {}   -- (src:sn)  -> frame number that confirmed (CS'd) it
 
 p_rasta.fields = {
 -- redundancy layer
@@ -143,6 +147,8 @@ p_rasta.fields = {
     safety_src_id,
     safety_sequence_number,
     safety_c_sequence_number,
+    safety_request_in,
+    safety_response_in,
     safety_timestamp,
     safety_c_timestamp,
     safety_data,
@@ -240,6 +246,44 @@ function p_rasta.dissector(buf, pktinfo, root)
     safety:add_le(safety_c_sequence_number,   buf:range(24, 4))
     safety:add_le(safety_timestamp,           buf:range(28, 4))
     safety:add_le(safety_c_timestamp,         buf:range(32, 4))
+
+    
+    local sn  = buf:range(20, 4):le_uint()
+    local cs  = buf:range(24, 4):le_uint()
+    local src = buf:range(16, 4):le_uint()
+    local dst = buf:range(12, 4):le_uint()
+
+    -- Record this packet: keyed by (sender, sn) so that a future CS from the peer can find it.
+    local sn_key = string.format("%d:%d", src, sn)
+    if not rasta_sn_table[sn_key] then
+        rasta_sn_table[sn_key] = pktinfo.number
+    end
+
+    -- This packet's CS acknowledges a packet previously sent by 'dst' with SN == cs.
+    -- Look up that original packet and:
+    --   1. Add a "Response In" link on the original packet (request_in shown on the response side).
+    --   2. Add a "Request In"   link on this packet pointing back to the original.
+    local cs_key = string.format("%d:%d", dst, cs)
+    local original_frame = rasta_sn_table[cs_key]
+    if original_frame then
+        -- "Response In" on this packet: the original request is at original_frame
+        local resp_item = safety:add(safety_response_in, buf:range(24, 4), original_frame)
+        resp_item:set_generated()
+
+        -- Remember that original_frame was confirmed/responded-to by our current frame.
+        -- This is used when the original packet is dissected (on reload) to show "Request In".
+        if not rasta_cs_table[cs_key] then
+            rasta_cs_table[cs_key] = pktinfo.number
+        end
+    end
+
+    -- If a later packet has already recorded a response for our SN, show it here.
+    local response_frame = rasta_cs_table[sn_key]
+    if response_frame then
+        local req_item = safety:add(safety_request_in, buf:range(20, 4), response_frame)
+        req_item:set_generated()
+    end
+
 
     if (msg_type:le_uint() == 6200 or msg_type:le_uint() == 6201) then
         -- connection request or connection response


### PR DESCRIPTION
Automatic correlation between RaSTA request and response packets based on sequence number (SN) and confirmed sequence number (CS) fields, similar to request/response tracking in other Wireshark dissectors (HTTP, DNS, etc.).

**Problem**
When analyzing RaSTA protocol captures, it was difficult to identify which packets were responses to specific requests. The RaSTA protocol uses a handshake mechanism where:

Sender A -> Receiver B: Uses sequence number `SN` and confirmed sequence number `CS`
Response B -> Sender A: Uses `SN` = A's previous CS + 1 and `CS` = A's last SN

Without automatic linking, users had to manually correlate packets by examining sequence numbers.

**Solution**
Added bidirectional packet correlation using two lookup tables:

`rasta_sn_table`: Maps `(sender_id:sn)` -> frame number where that packet was sent
`rasta_cs_table`: Maps `(sender_id:sn)` -> frame number that confirmed/responded to it


The dissector now:

1. Records each packet's `(src, sn)` for future lookups
2. When a packet's `CS` field acknowledges a previous packet, creates cross-references between them
3. Displays clickable frame links in the protocol tree:
    * "Response In: frame N" on the original request (links to the response) 
    * "Request In: frame M" on the response (links back to the original request)

<img width="1121" height="620" alt="WS_screenshot" src="https://github.com/user-attachments/assets/4eaaae69-03bb-4e73-93ea-36429864777f" />