### PR TITLE
Guard data_length against negative values on malformed packets

### DIFF
--- a/dissectors/rasta.lua
+++ b/dissectors/rasta.lua
@@ -228,7 +228,7 @@ function p_rasta.dissector(buf, pktinfo, root)
     local safety_length = buf:range(8,2):le_uint()
 
     -- length of the actual payload data. Should be 0 for non data packets.
-    local data_length = safety_length - 28 - p_rasta.prefs.safety_code_len
+    local data_length = math.max(0, safety_length - 28 - p_rasta.prefs.safety_code_len)
 
     -- print("pktlen=" .. pktlen)
     -- print("data_length=" .. data_length)


### PR DESCRIPTION
Guard data_length against negative values on malformed packets

## Summary
Adds a defensive clamp to `data_length` to prevent Lua errors when
dissecting truncated or malformed packets.

## Background
`data_length` is calculated as:
```lua
local data_length = safety_length - 28 - p_rasta.prefs.safety_code_len
```
If a malformed or truncated packet arrives with a `safety_length`
smaller than expected, this subtraction produces a negative number.
That negative value is later used as a buffer range length, which
causes a Lua error and the packet fails to dissect entirely.

## Impact
- Normal valid traffic is completely unaffected
- Malformed or fuzzed packets dissect cleanly instead of crashing